### PR TITLE
0.17.2 compatible db_utils version.

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: fishtown-analytics/dbt_utils
-    version: [">=0.4.0"]
-  
+    version: 0.5.1
+
   - package: fivetran/hubspot_source
     version: 0.1.0


### PR DESCRIPTION
For maintaining compatibility with dbt `0.17.2`, which is the version used by Fivetran + dbt functionality.