### PR TITLE
explicit better than implicit (or in this case global)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,44 +63,45 @@ When setting up your Hubspot connection in Fivetran, it is possible that not eve
 config-version: 2
 
 vars:
+  hubspot:
 
-  # Marketing
+    # Marketing
 
-  hubspot_marketing_enabled: false                        # Disables all marketing models
-  hubspot_contact_enabled: false                          # Disables the contact models
-  hubspot_contact_list_enabled: false                     # Disables contact list models
-  hubspot_contact_list_member_enabled: false              # Disables contact list member models
-  hubspot_contact_property_enabled: false                 # Disables the contact property models
-  hubspot_email_event_enabled: false                      # Disables all email_event models and functionality
-  hubspot_email_event_bounce_enabled: false
-  hubspot_email_event_deferred_enabled: false
-  hubspot_email_event_delivered_enabled: false
-  hubspot_email_event_dropped_enabled: false
-  hubspot_email_event_forward_enabled: false
-  hubspot_email_event_click_enabled: false
-  hubspot_email_event_opens_enabled: false
-  hubspot_email_event_print_enabled: false
-  hubspot_email_event_sent_enabled: false
-  hubspot_email_event_spam_report_enabled: false
-  hubspot_email_event_status_change_enabled: false
+    hubspot_marketing_enabled: false                        # Disables all marketing models
+    hubspot_contact_enabled: false                          # Disables the contact models
+    hubspot_contact_list_enabled: false                     # Disables contact list models
+    hubspot_contact_list_member_enabled: false              # Disables contact list member models
+    hubspot_contact_property_enabled: false                 # Disables the contact property models
+    hubspot_email_event_enabled: false                      # Disables all email_event models and functionality
+    hubspot_email_event_bounce_enabled: false
+    hubspot_email_event_deferred_enabled: false
+    hubspot_email_event_delivered_enabled: false
+    hubspot_email_event_dropped_enabled: false
+    hubspot_email_event_forward_enabled: false
+    hubspot_email_event_click_enabled: false
+    hubspot_email_event_opens_enabled: false
+    hubspot_email_event_print_enabled: false
+    hubspot_email_event_sent_enabled: false
+    hubspot_email_event_spam_report_enabled: false
+    hubspot_email_event_status_change_enabled: false
   
-  hubspot_contact_merge_audit_enabled: true               # Enables contact merge auditing to be applied to final models (removes any merged contacts that are still persisting in the contact table)
+    hubspot_contact_merge_audit_enabled: true               # Enables contact merge auditing to be applied to final models (removes any merged contacts that are still persisting in the contact table)
 
-  # Sales
+    # Sales
 
-  hubspot_sales_enabled: false                            # Disables all sales models
-  hubspot_company_enabled: false
-  hubspot_deal_enabled: false
-  hubspot_deal_company_enabled: false
-  hubspot_engagement_enabled: false                       # Disables all engagement models and functionality
-  hubspot_engagement_contact_enabled: false
-  hubspot_engagement_company_enabled: false
-  hubspot_engagement_deal_enabled: false
-  hubspot_engagement_calls_enabled: false
-  hubspot_engagement_emails_enabled: false
-  hubspot_engagement_meetings_enabled: false
-  hubspot_engagement_notes_enabled: false
-  hubspot_engagement_tasks_enabled: false
+    hubspot_sales_enabled: false                            # Disables all sales models
+    hubspot_company_enabled: false
+    hubspot_deal_enabled: false
+    hubspot_deal_company_enabled: false
+    hubspot_engagement_enabled: false                       # Disables all engagement models and functionality
+    hubspot_engagement_contact_enabled: false
+    hubspot_engagement_company_enabled: false
+    hubspot_engagement_deal_enabled: false
+    hubspot_engagement_calls_enabled: false
+    hubspot_engagement_emails_enabled: false
+    hubspot_engagement_meetings_enabled: false
+    hubspot_engagement_notes_enabled: false
+    hubspot_engagement_tasks_enabled: false
 ```
 
 


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
Doug Shawhan, Developer ConstructConnect.com

**What change(s) does this PR introduce?** 
Changes only to `README.md`. Explicitly moves `*_enabled` models into `hubspot` namespace for clarity. I spent entirely too much time staring at my `dbt_project.yml` wondering why my excluded models were being ignored. @fivetran-joemarkiewicz  (who was supposed to be on VACATION according to his slack palm tree) hit me with the cluebat.

Setting the exclusions as global directly under `vars` is fine, but gets a bit confusing when the config instructions:

```yaml
# dbt_project.yml

...
config-version: 2

vars:
  hubspot_source:
    hubspot_database: your_database_name
    hubspot_schema: your_schema_name
```

reference `hubspot_source`. It's entirely too easy to miss the position of the models in the example. In my case:

```yaml
  hubspot_source:
    hubspot_database: data-lake
    hubspot_schema: hubspot
    hubspot_email_event_forward_enabled: false
    hubspot_email_event_print_enabled: false

  hubspot:
    hubspot_email_event_forward_enabled: false
    hubspot_email_event_print_enabled: false
```
Appears much clearer, and reminds readers unfamiliar with `dbt_hubspot*` that there are two namespaces affected.

**Does this PR introduce a breaking change?**

- [ ] Yes (please provide breaking change details below.)
- [X] No  (please provide explanation how the change is non breaking below.)
Just the docs.

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [ ] Yes, Issue [link issue number here]
- [X] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [X] Other (please provide additional testing details below)

Laid my eyes on it in `github`.

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [X] BigQuery
- [ ] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

Documentation change in README.md matches local configuration. Runs great.

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
