### PR TITLE
Update quickstart.yml

### DIFF
--- a/.quickstart/quickstart.yml
+++ b/.quickstart/quickstart.yml
@@ -125,7 +125,5 @@ public_models: [
   "hubspot__companies",
   "hubspot__deal_stages",
   "hubspot__deals",
-  "hubspot__engagements",
-  "hubspot__daily_ticket_history",
-  "hubspot__tickets"
+  "hubspot__engagements"
 ]


### PR DESCRIPTION
Tiny PR to update the quickstart.yml to exclude disabled by default models from the public models config.