### PR TITLE
Feature: Add Quickstart Model Counts to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt_hubspot version.version
+
+## Documentation
+- Added Quickstart model counts to README. ([#152](https://github.com/fivetran/dbt_hubspot/pull/152))
+- Corrected references to connectors and connections in the README. ([#152](https://github.com/fivetran/dbt_hubspot/pull/152))
+
 # dbt_hubspot v0.20.0
 [PR #150](https://github.com/fivetran/dbt_hubspot/pull/150) includes the following updates:
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The following table provides a detailed list of all tables materialized within t
 | [hubspot__email_event_*](https://fivetran.github.io/dbt_hubspot/#!/model/model.hubspot.hubspot__email_event_bounce)   | Each record represents an email event in Hubspot, joined with relevant tables to make them analysis-ready.           |
 | [hubspot__email_sends](https://fivetran.github.io/dbt_hubspot/#!/model/model.hubspot.hubspot__email_sends)     | Each record represents a sent email in Hubspot, enriched with metrics about opens, clicks, and other email activity. |
 | [hubspot__engagement_*](https://fivetran.github.io/dbt_hubspot/#!/model/model.hubspot.hubspot__engagement_calls)    | Each record represents an engagement event in Hubspot, joined with relevant tables to make them analysis-ready.      |
+### Materialized Models
+Each Quickstart transformation job run materializes 129 models if all components of this data model are enabled. This count includes all staging, intermediate, and final models materialized as `view`, `table`, or `incremental`.
 <!--section-end-->
 
 ## How do I use the dbt package?
@@ -48,7 +50,7 @@ The following table provides a detailed list of all tables materialized within t
 ### Step 1: Prerequisites
 To use this dbt package, you must have the following:
 
-- At least one Fivetran HubSpot connector syncing data into your destination.
+- At least one Fivetran HubSpot connection syncing data into your destination.
 - A **BigQuery**, **Snowflake**, **Redshift**, **PostgreSQL**, or **Databricks** destination.
 
 #### Databricks Dispatch Configuration


### PR DESCRIPTION
Confirm the following files were correctly updated automatically:
- README 
  - [x] model count added
  - [x] `connector*` changed to `connection*` where necessary
- CHANGELOG 
  - [x] New entry created
    